### PR TITLE
Bugfix: Make sure notification titles from group chats are string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "id": "messenger",
   "name": "Messenger",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Facebook Messenger",
   "main": "index.js",
   "author": "Stefan Malzner <stefan@adlk.io>",

--- a/webview.js
+++ b/webview.js
@@ -10,14 +10,14 @@ module.exports = (Franz) => {
   };
 
   Franz.loop(getMessages);
+  
+  if (typeof Franz.onNotify === 'function') {
+    Franz.onNotify(notification => {
+      if (typeof notification.title !== 'string') {
+        notification.title = ((notification.title.props || {}).content || [])[0] || 'Messenger';
+      }
 
-  Franz.onNotify(notification => {
-
-    if (typeof notification.title !== 'string') {
-      notification.title = ((notification.title.props || {}).content || [])[0] || 'Messenger';
-    }
-
-    return notification;
-
-  });
+      return notification;
+    });
+  }
 };

--- a/webview.js
+++ b/webview.js
@@ -10,4 +10,14 @@ module.exports = (Franz) => {
   };
 
   Franz.loop(getMessages);
+
+  Franz.onNotify(notification => {
+
+    if (typeof notification.title !== 'string') {
+      notification.title = ((notification.title.props || {}).content || [])[0] || 'Messenger';
+    }
+
+    return notification;
+
+  });
 };


### PR DESCRIPTION
This resolves https://github.com/meetfranz/franz/issues/105
This changes make use of `onNotify` added in https://github.com/meetfranz/franz/pull/160