### PR TITLE
Enable notifications in Messenger settings by default

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -10,6 +10,9 @@ module.exports = (Franz) => {
   };
 
   Franz.loop(getMessages);
+  
+  /* Enable desktop notifications in messenger settings */
+  localStorage["_cs_desktopNotifsEnabled"] = JSON.stringify({"__t":new Date().getTime(), "__v":true})
 
   if (typeof Franz.onNotify === 'function') {
     Franz.onNotify((notification) => {


### PR DESCRIPTION
By default, messenger disables desktop notifications, which can be confusing for Franz users, who disable service notifications in the Franz settings.

Addresses #5 and https://github.com/meetfranz/franz/issues/536
  