### PR TITLE
Removed redirecting all links to Facebook

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -11,6 +11,16 @@ module.exports = (Franz) => {
 
   Franz.loop(getMessages);
 
+  /* Fixes links to be opened directly without prompt that user is leaving Facebook */
+  const fixLinks = function fixLinks() {
+    const links = document.querySelectorAll('a[data-lynx-uri]');
+    links.forEach(link => {
+      link.setAttribute('data-lynx-uri', link.href);
+    });
+  };
+
+  Franz.loop(fixLinks);
+
   /* Enable desktop notifications in messenger settings */
   localStorage.setItem('_cs_desktopNotifsEnabled', JSON.stringify({ __t: new Date().getTime(), __v: true }));
 


### PR DESCRIPTION
**Issue description**
Currently when clicking links in Messenger every link goes through Facebook. In case, when in a browser we are not logged in to Facebook it leads to a situation, where instead of the requested page we get a message that we are leaving Facebook. It's annoying, because it forces user to do another click. The same situation is while copying a link.

**How the problem was approached**
Generally, Messenger keeps with each link data attribute data-lynx-uri where it keeps URL to redirection page. It swaps href to data-lynx-uri when user hovers over the link. It doesn't check the contents of data-lynx-url, so we can safely input there our href, to keep link as we want it.
